### PR TITLE
#1481 Support for layered navigation to show product count.

### DIFF
--- a/src/etc/graphql/di.xml
+++ b/src/etc/graphql/di.xml
@@ -31,6 +31,7 @@
                 <item name="cookie_lifetime" xsi:type="string">web/cookie/cookie_lifetime</item>
                 <item name="plp_list_mode" xsi:type="string">catalog/frontend/list_mode</item>
                 <item name="product_use_categories" xsi:type="string">catalog/seo/product_use_categories</item>
+                <item name="layered_navigation_product_count_enabled" xsi:type="string">catalog/layered_navigation/display_product_count</item>
             </argument>
         </arguments>
     </type>

--- a/src/etc/schema.graphqls
+++ b/src/etc/schema.graphqls
@@ -36,6 +36,7 @@ type StoreConfig {
     plp_list_mode: String @doc(description: "PLP list mode")
     priceTaxDisplay: PriceTaxDisplay @resolver(class: "ScandiPWA\\StoreGraphQl\\Model\\Resolver\\PriceTaxDisplayResolver") @doc(description: "The price tax display mode")
     product_use_categories: String @doc(description: "Use Categories Path for Product URLs")
+    layered_navigation_product_count_enabled: Boolean @doc(description: "Should layered navigation display product count")
 }
 
 type PriceTaxDisplay {


### PR DESCRIPTION
Original issue [#1481](https://github.com/scandipwa/scandipwa/issues/1481)

Adds configuration field for:
* [_layered_navigation_product_count_enabled_] - Used to show product count in layered navigation.