### PR TITLE
[#1617] Adjust endpoint for graphql getting customers minimun password length setting

### DIFF
--- a/src/etc/graphql/di.xml
+++ b/src/etc/graphql/di.xml
@@ -52,6 +52,7 @@
                 <item name="time_format" xsi:type="string">catalog/custom_options/time_format</item>
                 <item name="is_allowed_reorder" xsi:type="string">sales/reorder/allow</item>
                 <item name="rss_order_subscribe_allow" xsi:type="string">rss/order/status</item>
+                <item name="minimun_password_length" xsi:type="string">customer/password/minimum_password_length</item>
             </argument>
         </arguments>
     </type>

--- a/src/etc/schema.graphqls
+++ b/src/etc/schema.graphqls
@@ -57,6 +57,7 @@ type StoreConfig {
     time_format: String @doc(description: "24h or 12h + AM/PM format")
     is_allowed_reorder: Boolean @doc(desription: "Defines if customer is allowed to reorder")
     rss_order_subscribe_allow: Boolean @doc(description: "Defines if customer is allowed to subscribe to order status")
+    minimun_password_length: Int @doc(description: "Defines password minimun length for customer")
 }
 
 type PriceTaxDisplay {


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/1617

**Problem:**
* Password input do not take into account the password length setting set up in the admin panel.

**In this PR:**
* Adjust the endpoint for graphql to get customers minimun password length setting

**Related PRs**
* https://github.com/scandipwa/scandipwa/pull/4145
